### PR TITLE
Include inherited fields in nodedef listing

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -56,22 +56,32 @@ local function inspect_pos(pos)
 		end
 	end
 
+	desc = minetest.formspec_escape(desc)
+
 	if nodedef then  -- Some built in nodes have no nodedef
 
 		-- combine nodedef table with its "superclass" table
+		local combined_fields = {}
 		local nodedef_fields = {}
-		for key, value in pairs(getmetatable(nodedef).__index) do nodedef_fields[key] = value end
+		for key, value in pairs(getmetatable(nodedef).__index) do combined_fields[key] = value end
 		for key, value in pairs(nodedef) do 
-			if nodedef_fields[key] == nil then nodedef_fields[key] = value end
+			nodedef_fields[key] = true
+			if combined_fields[key] == nil then combined_fields[key] = value end
 		end
 
 		-- sort
 		local key_list = {}
-		for key, _ in pairs(nodedef_fields) do table.insert(key_list, key) end
+		for key, _ in pairs(combined_fields) do table.insert(key_list, key) end
 		table.sort(key_list)
 
 		desc = desc .. "==== nodedef ====\n"
-		for _, key in ipairs(key_list) do desc = desc .. key .. " = " .. dump(nodedef[key]) .. "\n" end
+		for _, key in ipairs(key_list) do 
+			if nodedef_fields[key] then 
+				desc = desc .. minetest.formspec_escape(key .. " = " .. dump(nodedef[key]) .. "\n") 
+			else
+				desc = desc .. minetest.colorize("#CCC", key .. " = " .. minetest.formspec_escape(dump(nodedef[key])) .. "\n") 
+			end
+		end
 	end
 
 	return desc
@@ -98,13 +108,13 @@ minetest.register_tool("inspector:inspector", {
 		elseif pointed_thing.type == "object" then
 			local ref = pointed_thing.ref
 			local entity = ref:get_luaentity()
-			desc = dump(entity)
+			desc = minetest.formspec_escape(dump(entity))
 		end
 
 		local formspec = "size[12,8]"..
 				 "label[0.5,0.5;Node Information]"..
 				 "textarea[0.5,1.5;11.5,7;text;Contents:;"..
-				 minetest.formspec_escape(desc).."]"..
+				 desc.."]"..
 				 "button_exit[2.5,7.5;3,1;close;Close]"
 
 		fsc.show(user:get_player_name(), formspec, {}, function() end)
@@ -125,16 +135,17 @@ minetest.register_tool("inspector:inspector", {
 		elseif pointed_thing.type == "object" then
 			local ref = pointed_thing.ref
 			local entity = ref:get_luaentity()
-			desc = dump(entity)
+			desc = minetest.formspec_escape(dump(entity))
 		end
 
 		local formspec = "size[12,8]"..
 				 "label[0.5,0.5;Node Information]"..
 				 "textarea[0.5,1.5;11.5,7;text;Contents:;"..
-				 minetest.formspec_escape(desc).."]"..
+				 desc.."]"..
 				 "button_exit[2.5,7.5;3,1;close;Close]"
 
 		fsc.show(user:get_player_name(), formspec, {}, function() end)
+
 	end
 })
 
@@ -155,7 +166,7 @@ minetest.register_chatcommand("inspect", {
 		local formspec = "size[12,8]"..
 							 "label[0.5,0.5;Node Information]"..
 							 "textarea[0.5,1.5;11.5,7;text;Contents:;"..
-							 minetest.formspec_escape(desc).."]"..
+							 desc.."]"..
 							 "button_exit[2.5,7.5;3,1;close;Close]"
 
 		fsc.show(name, formspec, {}, function() end)

--- a/init.lua
+++ b/init.lua
@@ -38,8 +38,8 @@ local function inspect_pos(pos)
 
 	local nodedef = minetest.registered_items[node.name]
 	local meta = minetest.get_meta(pos)
-	local table = meta:to_table()
-	local fields = minetest.serialize(table.fields)
+	local metatable = meta:to_table()
+	local fields = minetest.serialize(metatable.fields)
 	desc = desc .. "==== meta ====\n"
 	desc = desc .. "meta.fields = " .. fields .. "\n"
 	desc = desc .. "\n"
@@ -57,8 +57,21 @@ local function inspect_pos(pos)
 	end
 
 	if nodedef then  -- Some built in nodes have no nodedef
+
+		-- combine nodedef table with its "superclass" table
+		local nodedef_fields = {}
+		for key, value in pairs(getmetatable(nodedef).__index) do nodedef_fields[key] = value end
+		for key, value in pairs(nodedef) do 
+			if nodedef_fields[key] == nil then nodedef_fields[key] = value end
+		end
+
+		-- sort
+		local key_list = {}
+		for key, _ in pairs(nodedef_fields) do table.insert(key_list, key) end
+		table.sort(key_list)
+
 		desc = desc .. "==== nodedef ====\n"
-		desc = desc .. dump(nodedef) .. "\n"
+		for _, key in ipairs(key_list) do desc = desc .. key .. " = " .. dump(nodedef[key]) .. "\n" end
 	end
 
 	return desc


### PR DESCRIPTION
Includes the values for nodedef's inherited fields, so the inspector will always show things like `is_ground_content`, and displays them all in a sorted list.

I'm not sure if you want that though, or would rather the two lists be displayed separately, or perhaps the inherited default values should be marked clearly so you know the node hasn't changed that value. So don't feel you ought to pull this - it's useful to me as I don't know all the properties of a nodedef but it might hinder others.

I tried to colourize the text so default values would be grey but still displayed, but I think there are formspec limitations preventing that.

You probably shouldn't pull in the Colorize commit, I failed to make a separate feature fork so it was automatically appended to this PR. I'll replace this PR with a feature branch when I get a moment.