### PR TITLE
Include inherited fields when showing nodedef values

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -38,8 +38,8 @@ local function inspect_pos(pos)
 
 	local nodedef = minetest.registered_items[node.name]
 	local meta = minetest.get_meta(pos)
-	local table = meta:to_table()
-	local fields = minetest.serialize(table.fields)
+	local metatable = meta:to_table()
+	local fields = minetest.serialize(metatable.fields)
 	desc = desc .. "==== meta ====\n"
 	desc = desc .. "meta.fields = " .. fields .. "\n"
 	desc = desc .. "\n"
@@ -57,8 +57,21 @@ local function inspect_pos(pos)
 	end
 
 	if nodedef then  -- Some built in nodes have no nodedef
+
+		-- combine nodedef table with its "superclass" table
+		local combined_fields = {}
+		for key, value in pairs(getmetatable(nodedef).__index) do combined_fields[key] = value end
+		for key, value in pairs(nodedef) do 
+			if combined_fields[key] == nil then combined_fields[key] = value end
+		end
+
+		-- sort
+		local key_list = {}
+		for key, _ in pairs(combined_fields) do table.insert(key_list, key) end
+		table.sort(key_list)
+
 		desc = desc .. "==== nodedef ====\n"
-		desc = desc .. dump(nodedef) .. "\n"
+		for _, key in ipairs(key_list) do desc = desc .. key .. " = " .. dump(nodedef[key]) .. "\n" end
 	end
 
 	return desc

--- a/init.lua
+++ b/init.lua
@@ -18,15 +18,23 @@ local function make_fs(title, desc)
 		"button_exit[11.1,0.2;0.8,0.8;close;x]"
 end
 
+local indent_string = "     "
+
 local function indent(level, text, emphasize)
 	local result = text
 	for i = 1, level do
 		if emphasize then
-			result = "->  "  .. string.gsub(result, "\n", "\n     ")
+			result = "->  "        .. string.gsub(result, "\n", "\n" .. indent_string)
 		else 
-			result = "     " .. string.gsub(result, "\n", "\n     ")
+			result = indent_string .. string.gsub(result, "\n", "\n" .. indent_string)
 		end
 	end
+	return result
+end
+
+local function adjusted_dump(o)
+	local result = dump(o, indent_string)
+	if result == "{\n" .. indent_string .. "\n}" then result = "{}" end
 	return result
 end
 
@@ -51,10 +59,8 @@ local function inspect_pos(pos)
 	local nodedef = minetest.registered_items[node.name]
 	local meta = minetest.get_meta(pos)
 	local metatable = meta:to_table()
-	local fields = minetest.serialize(metatable.fields)
 	desc = desc .. "==== meta ====\n"
-	desc = desc .. indent(1, "meta.fields = " .. fields) .. "\n"
-	desc = desc .. "\n"
+	desc = desc .. indent(1, "meta.fields = " .. adjusted_dump(metatable.fields)) .. "\n"
 	local inventory = meta:get_inventory()
 	desc = desc .. indent(1, "meta.inventory = ") .. "\n"
 	for key, list in pairs(inventory:get_lists()) do
@@ -86,7 +92,7 @@ local function inspect_pos(pos)
 
 		desc = desc .. "==== nodedef ====\n"
 		for _, key in ipairs(key_list) do 
-			desc = desc .. indent(1, key .. " = " .. dump(nodedef[key]), nodedef_fields[key]) .. "\n"
+			desc = desc .. indent(1, key .. " = " .. adjusted_dump(nodedef[key]), nodedef_fields[key]) .. "\n"
 		end
 	end
 


### PR DESCRIPTION
* Shows the values the nodedef has inherited, so the inspector will always include properties like `is_ground_content` (rather than only showing it if it's false).
* Nodedef fields are listed alphabetically.
* Values which the nodedef has changed (instead of inherited) are marked with a "->"
* moar indentation

Example on right:
![inspector indent](https://user-images.githubusercontent.com/6390507/60590683-f24e5b00-9ddf-11e9-9a30-e958f7698bf1.png)


