### PR TITLE
Add location information

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -96,6 +96,24 @@ local function inspect_pos(pos)
 		end
 	end
 
+	desc = desc .. "\n==== Location ====\n"
+	desc = desc .. indent(1, "position = " .. minetest.pos_to_string(pos)) .. "\n"
+	if minetest.get_biome_data ~= nil and minetest.registered_biomes ~= nil then
+		local biomeData = minetest.get_biome_data(pos)
+
+		desc = desc .. indent(1, "heat = "     .. tostring(biomeData.heat))     .."\n"
+		desc = desc .. indent(1, "humidity = " .. tostring(biomeData.humidity)) .. "\n"
+		local biomeDescription = "<none>"
+		if biomeData.biome ~= nil then
+			local biomeName = minetest.get_biome_name(biomeData.biome)
+			biomeDescription = biomeName
+
+			local biomeTable = minetest.registered_biomes[biomeName]
+			if biomeTable ~= nil then biomeDescription = biomeDescription .. " " .. adjusted_dump(biomeTable) end
+		end
+		desc = desc .. indent(1, "biome = " .. biomeDescription) .. "\n"
+	end
+
 	return desc
 end
 


### PR DESCRIPTION
Show node's location and the environment/biome for that location

I'm not sure if this is of much interest to others, so it's at the bottom of the desc and you have to scroll down if you want to see those details.

Biome details are a MT 5 feature. Currently this inspector only shows the position in MT 0.4.x, which isn't very useful - but point is I've run it on 0.4 and confirmed it didn't break anything ;)

![image](https://user-images.githubusercontent.com/6390507/70887806-e6bfbb00-2032-11ea-9543-3087b403c8b1.png)
